### PR TITLE
Fix README link to License

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ You can call your file whatever your want. I am using my last name for my files 
 
 ## Contributor License Agreement
 
-- All accepted submissions to this repo will be licensed under [The Unlicense](https://github.com/CLSummit/CLS2018/blob/master/LICENSE).
+- All accepted submissions to this repo will be licensed under [The Unlicense](https://github.com/CLSummit/CLS2018/blob/master/LICENSE.md).


### PR DESCRIPTION
Commit 8f82b90bd16224136fa573b100677371faa373c3 renamed the license from `LICENSE` to `LICENSE.md` and broke the link in `README.md`. This change fixes the broken link.